### PR TITLE
Iframe support

### DIFF
--- a/cube-of-truth/embed.html
+++ b/cube-of-truth/embed.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cube of Truth iframe embed</title>
+    <link rel="stylesheet" href="/dist/wd-player.css" />
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+      #player {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <video id="player" />
+    <script src="/dist/wd-player.umd.js"></script>
+    <script>
+      wdplayer("#player", { color: "#333", movie: "cube-of-truth" });
+    </script>
+  </body>
+</html>

--- a/dominion/embed.html
+++ b/dominion/embed.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dominion iframe embed</title>
+    <link rel="stylesheet" href="/dist/wd-player.css" />
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+      #player {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <video id="player" />
+    <script src="/dist/wd-player.umd.js"></script>
+    <script>
+      wdplayer("#player", { color: "#f4c41a" });
+    </script>
+  </body>
+</html>

--- a/dont-watch/embed.html
+++ b/dont-watch/embed.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dontwatch iframe embed</title>
+    <link rel="stylesheet" href="/dist/wd-player.css" />
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+      #player {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <video id="player" />
+    <script src="/dist/wd-player.umd.js"></script>
+    <script>
+      wdplayer("#player", { color: "#f00", movie: "dont-watch" });
+    </script>
+  </body>
+</html>

--- a/embed.html
+++ b/embed.html
@@ -1,0 +1,1 @@
+./dominion/embed.html

--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
       />
     </noscript>
 
-    <link rel="stylesheet" href="./dist/app.css" />
-    <link rel="stylesheet" href="./dist/wd-player.css" />
+    <link rel="stylesheet" href="/dist/app.css" />
+    <link rel="stylesheet" href="/dist/wd-player.css" />
   </head>
   <body class="bg-dark text-white">
     <main class="relative flex flex-col">
@@ -159,7 +159,7 @@ wdplayer("#player", {
       </div>
     </footer>
 
-    <script src="./dist/wd-player.umd.js"></script>
+    <script src="/dist/wd-player.umd.js"></script>
     <script>
       // Auto select everything inside pre tags on click.
       function onClick(event) {

--- a/lib/player.ts
+++ b/lib/player.ts
@@ -84,7 +84,7 @@ export default async function wdplayer(
   }
 
   // Create captions that work for both maps and arrays.
-  let localeLabels = movie.captions;
+  let localeLabels = movie.captions ?? {};
   if (Array.isArray(movie.captions)) {
     localeLabels = createLocaleMap(movie.captions);
   }


### PR DESCRIPTION
- Add support for frames, by providing HTML files with the player already embedded.
  Each file is available at `https://embed.watchdominion.com/{cube-of-truth,dominion,dont-watch}/embed.html`. You can use this URL as the src of the iframe.
- Make captions optional. Before this would result into an error when initiating a movie without captions.
- Replace relative paths with absolute ones.